### PR TITLE
Improve default admonition message

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If today is 2022-09-11 and the date on the note is 2022-09-01,
 - It shows `10 days passed!` if you set `${numberOfDays} days passed!`
 - It shows `10 days passed since 2022-09-01` if you set `${numberOfDays} days passed since ${date}`
 
-`Default: The content has been no updated for over ${numberOfDays} days`
+Default: `The following content hasn't been updated in the last ${numberOfDays} days`
 
 #### Date to be referred
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,7 +27,7 @@ export interface Settings {
 export const DEFAULT_SETTINGS: Settings = {
   minNumberOfDaysToShowWarning: 180,
   messageTemplate:
-    "The content has been no updated for over ${numberOfDays} days",
+    "The following content hasn't been updated in the last ${numberOfDays} days",
   showWarningIfDataIsNotFound: false,
   triggerToUpdate: "On open file",
   dateToBeReferred: "Modified time",


### PR DESCRIPTION
I'll start off by saying I understand this PR is opinionated. Therefore, if you disagree with it, it's fine to close it.
It was just such a simple edit, I thought I might as well offer a PR instead of opening an issue.

Note that the current default message actually contains an error. This PR is both my opinion of an improvement and a fix. If accepting the PR is undesirable, I suggest fixing this separately:

"The content **has been no** updated for over"

Should be (at the very least)

"The content **has not been** updated for over"

I also think that "for over" would fit better with the *minimum* amount of days configured, rather than the exact time since the last update. If I understand correctly, in "...for over 365 days", the over is basically equating to 365 days, plus a few hours and/or minutes, which makes it seem a little unnecessary.

Hopefully this isn't rude, as that is not my intent. Just saw a tiny mistake in an otherwise nice plugin, and it bothered me enough to fix it.